### PR TITLE
no longer throws warnings

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,3 +10,4 @@ tox
 black
 isort
 pre-commit
+pytest

--- a/src/elexsolver/QuantileRegressionSolver.py
+++ b/src/elexsolver/QuantileRegressionSolver.py
@@ -45,7 +45,7 @@ class QuantileRegressionSolver:
                 f"Ill-conditioned matrix detected. Matrix condition number >= {self.CONDITION_ERROR_MIN}"
             )
         elif condition_number >= self.CONDITION_WARNING_MIN:
-            LOG.warn("Ill-conditioned matrix detected. result is not guaranteed to be accurate")
+            LOG.warning("Ill-conditioned matrix detected. result is not guaranteed to be accurate")
             return False
         return True
 


### PR DESCRIPTION
## Description
`LOG.warn` was deprecated in python 3.3, this PR replaces it with `LOG.warning`.

## Jira Ticket
https://arcpublishing.atlassian.net/browse/ELEX-2419

## Test Steps
This should throw a deprecation warning
```
git checkout develop
tox
```

This should no longer throw a deprecation warning:
```
git checkout elex-2419-replace-warn
tox
```