### PR TITLE
elex-2331-nan-tests

### DIFF
--- a/src/elexsolver/QuantileRegressionSolver.py
+++ b/src/elexsolver/QuantileRegressionSolver.py
@@ -78,12 +78,12 @@ class QuantileRegressionSolver:
         Weights should not sum to one.
         """
 
-        if  np.any(np.isnan(x)):
+        if np.any(np.isnan(x)):
             LOG.warning("Warning: NaN values in reporting_units_features")
 
-        if  np.any(np.isnan(y)):
+        if np.any(np.isnan(y)):
             LOG.warning("Warning: NaN values in reporting_units_residuals")
-        
+
         if weights is None:  # if weights are none, give unit weights
             weights = [1] * x.shape[0]
         if normalize_weights:

--- a/src/elexsolver/QuantileRegressionSolver.py
+++ b/src/elexsolver/QuantileRegressionSolver.py
@@ -49,6 +49,13 @@ class QuantileRegressionSolver:
             return False
         return True
 
+    def _check_any_element_nan_or_inf(self, x):
+        """
+        Check whether any element in a matrix or vector is NaN or infinity
+        """
+        if np.any(np.isnan(x)) or np.any(np.isinf(x)):
+            raise ValueError("Array contains NaN or Infinity")
+
     def get_loss_function(self, x, y, coefficients, weights):
         y_hat = x @ coefficients
         residual = y - y_hat
@@ -78,11 +85,8 @@ class QuantileRegressionSolver:
         Weights should not sum to one.
         """
 
-        if np.any(np.isnan(x)):
-            LOG.warning("Warning: NaN values in reporting_units_features")
-
-        if np.any(np.isnan(y)):
-            LOG.warning("Warning: NaN values in reporting_units_residuals")
+        self._check_any_element_nan_or_inf(x)
+        self._check_any_element_nan_or_inf(y)
 
         if weights is None:  # if weights are none, give unit weights
             weights = [1] * x.shape[0]
@@ -105,7 +109,6 @@ class QuantileRegressionSolver:
         """
         Returns predictions
         """
-        if np.any(np.isnan(x)):
-            LOG.warning("Warning: NaN values in nonreporting_units_features")
+        self._check_any_element_nan_or_inf(x)
 
         return self.coefficients @ x.T

--- a/src/elexsolver/QuantileRegressionSolver.py
+++ b/src/elexsolver/QuantileRegressionSolver.py
@@ -77,6 +77,13 @@ class QuantileRegressionSolver:
         Fit the (weighted) quantile regression problem.
         Weights should not sum to one.
         """
+
+        if  np.any(np.isnan(x)):
+            LOG.warning("Warning: NaN values in reporting_units_features")
+
+        if  np.any(np.isnan(y)):
+            LOG.warning("Warning: NaN values in reporting_units_residuals")
+        
         if weights is None:  # if weights are none, give unit weights
             weights = [1] * x.shape[0]
         if normalize_weights:
@@ -98,4 +105,7 @@ class QuantileRegressionSolver:
         """
         Returns predictions
         """
+        if np.any(np.isnan(x)):
+            LOG.warning("Warning: NaN values in nonreporting_units_features")
+
         return self.coefficients @ x.T

--- a/tests/test_quantile.py
+++ b/tests/test_quantile.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+import warnings
 
 from elexsolver.QuantileRegressionSolver import IllConditionedMatrixException, QuantileRegressionSolver
 
@@ -137,26 +138,6 @@ def test_random_upper_weights(random_data_weights):
     quantreg.fit(x, y, tau, weights=weights)
     quantreg.predict(x)
     assert all(np.abs(quantreg.coefficients - [3.47742, 2.07360, 4.51754, 4.15237, 9.58856]) <= TOL)
-
-
-def test_nan_warnings(random_data_weights):
-    quantreg = QuantileRegressionSolver()
-    tau = 0.9
-    x = random_data_weights[["x0", "x1", "x2", "x3", "x4"]].values
-    y = random_data_weights["y"].values
-
-    with pytest.warns(None):
-        quantreg.fit(x, y, tau)
-
-    x = np.vstack([x, [4, 2, 6, 8, 3]])
-    y = np.append(y, np.nan)
-    with pytest.warns(UserWarning):
-        quantreg.fit(x, y, tau)
-
-    quantreg.coefficients = [4, 32, 4, 24, 7]
-    x = np.vstack([x, [4, 2, 6, np.nan, 3]])
-    # with pytest.warns(UserWarning):
-    #     quantreg.predict(np.vstack([x, [4,2,6,np.nan,3]]))
 
 
 ########################
@@ -304,3 +285,40 @@ def test_ill_conditioned_warning():
     x = random_number_generator.multivariate_normal(mu, sigma, size=3)
     matrix_check = quantreg._check_matrix_condition(x)
     assert matrix_check
+
+
+########################
+# Test checking NaN/Inf #
+########################
+
+def test_no_nan_inf_error(random_data_weights):
+    quantreg = QuantileRegressionSolver()
+    tau = 0.9
+    x = random_data_weights[["x0", "x1", "x2", "x3", "x4"]].values
+    y = random_data_weights["y"].values
+
+    x[0, 0] = np.nan
+    with pytest.raises(ValueError):
+        quantreg.fit(x, y, tau)
+    
+    x[0, 0] = np.inf
+    with pytest.raises(ValueError):
+        quantreg.fit(x, y, tau)
+
+    x = random_data_weights[["x0", "x1", "x2", "x3", "x4"]].values
+    y[5] = np.nan
+    with pytest.raises(ValueError):
+        quantreg.fit(x, y, tau)
+    
+    y[5] = np.inf
+    with pytest.raises(ValueError):
+        quantreg.fit(x, y, tau)
+
+    quantreg.coefficients = [4, 32, 4, 24, 7]
+    x = np.vstack([x, [4, 2, 6, np.nan, 3]])
+    with pytest.raises(ValueError):
+        quantreg.predict(x)
+
+    x = np.vstack([x, [4, 2, 6, np.inf, 3]])
+    with pytest.raises(ValueError):
+        quantreg.predict(x)

--- a/tests/test_quantile.py
+++ b/tests/test_quantile.py
@@ -144,24 +144,25 @@ def test_nan_warnings(random_data_weights):
     tau = 0.9
     x = random_data_weights[["x0", "x1", "x2", "x3", "x4"]].values
     y = random_data_weights["y"].values
- 
-    with pytest.warns(None):
-        quantreg.fit(x, y, tau)            
 
-    x = np.vstack([x, [4,2,6,8,3]])
+    with pytest.warns(None):
+        quantreg.fit(x, y, tau)
+
+    x = np.vstack([x, [4, 2, 6, 8, 3]])
     y = np.append(y, np.nan)
     with pytest.warns(UserWarning):
         quantreg.fit(x, y, tau)
-        
-    quantreg.coefficients = [4,32, 4,24,7]
-    x = np.vstack([x, [4,2,6,np.nan,3]])
+
+    quantreg.coefficients = [4, 32, 4, 24, 7]
+    x = np.vstack([x, [4, 2, 6, np.nan, 3]])
     # with pytest.warns(UserWarning):
     #     quantreg.predict(np.vstack([x, [4,2,6,np.nan,3]]))
 
-        
+
 ########################
 # Test changing solver #
 ########################
+
 
 def test_changing_solver(random_data_no_weights):
     tau = 0.5

--- a/tests/test_quantile.py
+++ b/tests/test_quantile.py
@@ -155,8 +155,8 @@ def test_nan_warnings(random_data_weights):
         
     quantreg.coefficients = [4,32, 4,24,7]
     x = np.vstack([x, [4,2,6,np.nan,3]])
-    with pytest.warns(UserWarning):
-        quantreg.predict(np.vstack([x, [4,2,6,np.nan,3]]))
+    # with pytest.warns(UserWarning):
+    #     quantreg.predict(np.vstack([x, [4,2,6,np.nan,3]]))
 
         
 ########################

--- a/tests/test_quantile.py
+++ b/tests/test_quantile.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pytest
-import warnings
 
 from elexsolver.QuantileRegressionSolver import IllConditionedMatrixException, QuantileRegressionSolver
 
@@ -291,6 +290,7 @@ def test_ill_conditioned_warning():
 # Test checking NaN/Inf #
 ########################
 
+
 def test_no_nan_inf_error(random_data_weights):
     quantreg = QuantileRegressionSolver()
     tau = 0.9
@@ -300,7 +300,7 @@ def test_no_nan_inf_error(random_data_weights):
     x[0, 0] = np.nan
     with pytest.raises(ValueError):
         quantreg.fit(x, y, tau)
-    
+
     x[0, 0] = np.inf
     with pytest.raises(ValueError):
         quantreg.fit(x, y, tau)
@@ -309,7 +309,7 @@ def test_no_nan_inf_error(random_data_weights):
     y[5] = np.nan
     with pytest.raises(ValueError):
         quantreg.fit(x, y, tau)
-    
+
     y[5] = np.inf
     with pytest.raises(ValueError):
         quantreg.fit(x, y, tau)

--- a/tests/test_quantile.py
+++ b/tests/test_quantile.py
@@ -139,10 +139,29 @@ def test_random_upper_weights(random_data_weights):
     assert all(np.abs(quantreg.coefficients - [3.47742, 2.07360, 4.51754, 4.15237, 9.58856]) <= TOL)
 
 
+def test_nan_warnings(random_data_weights):
+    quantreg = QuantileRegressionSolver()
+    tau = 0.9
+    x = random_data_weights[["x0", "x1", "x2", "x3", "x4"]].values
+    y = random_data_weights["y"].values
+ 
+    with pytest.warns(None):
+        quantreg.fit(x, y, tau)            
+
+    x = np.vstack([x, [4,2,6,8,3]])
+    y = np.append(y, np.nan)
+    with pytest.warns(UserWarning):
+        quantreg.fit(x, y, tau)
+        
+    quantreg.coefficients = [4,32, 4,24,7]
+    x = np.vstack([x, [4,2,6,np.nan,3]])
+    with pytest.warns(UserWarning):
+        quantreg.predict(np.vstack([x, [4,2,6,np.nan,3]]))
+
+        
 ########################
 # Test changing solver #
 ########################
-
 
 def test_changing_solver(random_data_no_weights):
     tau = 0.5


### PR DESCRIPTION
## Description
We throw a `ValueError` exception if covariates or response variables are nan/inf at fitting time and when covariates are nan/inf at prediction time. We may want to catch that exception on use.

## Jira Ticket
https://arcpublishing.atlassian.net/browse/ELEX-2331

## Test Steps
`tox`