### PR TITLE
Fix/not regularizing intercept

### DIFF
--- a/src/elexsolver/QuantileRegressionSolver.py
+++ b/src/elexsolver/QuantileRegressionSolver.py
@@ -56,6 +56,9 @@ class QuantileRegressionSolver:
             raise ValueError("Array contains NaN or Infinity")
 
     def _check_intercept(self, x):
+        """
+        Check whether the first column is all 1s (normal intercept) otherwise raises a warning.
+        """
         if ~np.all(x[:, 0] == 1):
             warnings.warn("Warning: fit_intercept=True and not all elements of the first columns are 1s")
 

--- a/src/elexsolver/QuantileRegressionSolver.py
+++ b/src/elexsolver/QuantileRegressionSolver.py
@@ -83,7 +83,16 @@ class QuantileRegressionSolver:
         return coefficients, problem
 
     def fit(
-        self, x, y, tau_value=0.5, weights=None, lambda_=0, fit_intercept=True, verbose=False, save_problem=False, normalize_weights=True
+        self,
+        x,
+        y,
+        tau_value=0.5,
+        weights=None,
+        lambda_=0,
+        fit_intercept=True,
+        verbose=False,
+        save_problem=False,
+        normalize_weights=True,
     ):
         """
         Fit the (weighted) quantile regression problem.

--- a/src/elexsolver/QuantileRegressionSolver.py
+++ b/src/elexsolver/QuantileRegressionSolver.py
@@ -62,8 +62,8 @@ class QuantileRegressionSolver:
         return cp.sum(cp.multiply(weights, 0.5 * cp.abs(residual) + (self.tau.value - 0.5) * residual))
 
     def get_regularizer(self, coefficients, fit_intercept):
-        # coefficient for intercept should not get regularized
-        # NOTE: this now assumes that the first column is an intercept
+        # if we are fitting an intercept in the model, then that coefficient should not be regularized.
+        # NOTE: assumes that if fit_intercept=True, that the intercept is in the first column
         coefficients_to_regularize = coefficients
         if fit_intercept:
             coefficients_to_regularize = coefficients[1:]
@@ -88,6 +88,7 @@ class QuantileRegressionSolver:
         """
         Fit the (weighted) quantile regression problem.
         Weights should not sum to one.
+        If fit_intercept=True then intercept is assumed to be the first column in `x`
         """
 
         self._check_any_element_nan_or_inf(x)

--- a/src/elexsolver/QuantileRegressionSolver.py
+++ b/src/elexsolver/QuantileRegressionSolver.py
@@ -63,11 +63,17 @@ class QuantileRegressionSolver:
             warnings.warn("Warning: fit_intercept=True and not all elements of the first columns are 1s")
 
     def get_loss_function(self, x, y, coefficients, weights):
+        """
+        Get the quantile regression loss function
+        """
         y_hat = x @ coefficients
         residual = y - y_hat
         return cp.sum(cp.multiply(weights, 0.5 * cp.abs(residual) + (self.tau.value - 0.5) * residual))
 
     def get_regularizer(self, coefficients, fit_intercept):
+        """
+        Get regularization component of the loss function. Note that this is L2 (ridge) regularization.
+        """
         # if we are fitting an intercept in the model, then that coefficient should not be regularized.
         # NOTE: assumes that if fit_intercept=True, that the intercept is in the first column
         coefficients_to_regularize = coefficients

--- a/src/elexsolver/QuantileRegressionSolver.py
+++ b/src/elexsolver/QuantileRegressionSolver.py
@@ -1,5 +1,6 @@
 import logging
 import warnings
+
 import cvxpy as cp
 import numpy as np
 
@@ -55,7 +56,7 @@ class QuantileRegressionSolver:
             raise ValueError("Array contains NaN or Infinity")
 
     def _check_intercept(self, x):
-        if ~np.all(x[:,0] == 1):
+        if ~np.all(x[:, 0] == 1):
             warnings.warn("Warning: fit_intercept=True and not all elements of the first columns are 1s")
 
     def get_loss_function(self, x, y, coefficients, weights):

--- a/src/elexsolver/logging.py
+++ b/src/elexsolver/logging.py
@@ -31,4 +31,5 @@ def initialize_logging(logging_config=None):
         app_log_level = os.getenv("APP_LOG_LEVEL", "INFO")
         LOGGING_CONFIG["loggers"]["elexsolver"]["level"] = app_log_level
         logging_config = LOGGING_CONFIG
+    logging.captureWarnings(True)
     logging.config.dictConfig(logging_config)

--- a/tests/test_quantile.py
+++ b/tests/test_quantile.py
@@ -18,7 +18,7 @@ def test_basic_median_1():
     tau = 0.5
     x = np.asarray([[1], [1], [1], [2]])
     y = np.asarray([3, 8, 9, 15])
-    quantreg.fit(x, y, tau)
+    quantreg.fit(x, y, tau, fit_intercept=False)
     preds = quantreg.predict(x)
     # you'd think it would be 8 instead of 7.5, but run quantreg in R to confirm
     # has to do with missing intercept
@@ -65,7 +65,7 @@ def test_random_median(random_data_no_weights):
     tau = 0.5
     x = random_data_no_weights[["x0", "x1", "x2", "x3", "x4"]].values
     y = random_data_no_weights["y"].values
-    quantreg.fit(x, y, tau)
+    quantreg.fit(x, y, tau, fit_intercept=False)
     quantreg.predict(x)
     assert all(np.abs(quantreg.coefficients - [1.57699, 6.74906, 4.40175, 4.85346, 4.51814]) <= TOL)
 
@@ -75,7 +75,7 @@ def test_random_lower(random_data_no_weights):
     tau = 0.1
     x = random_data_no_weights[["x0", "x1", "x2", "x3", "x4"]].values
     y = random_data_no_weights["y"].values
-    quantreg.fit(x, y, tau)
+    quantreg.fit(x, y, tau, fit_intercept=False)
     quantreg.predict(x)
     assert all(np.abs(quantreg.coefficients - [0.17759, 6.99588, 4.18896, 4.83906, 3.22546]) <= TOL)
 
@@ -85,7 +85,7 @@ def test_random_upper(random_data_no_weights):
     tau = 0.9
     x = random_data_no_weights[["x0", "x1", "x2", "x3", "x4"]].values
     y = random_data_no_weights["y"].values
-    quantreg.fit(x, y, tau)
+    quantreg.fit(x, y, tau, fit_intercept=False)
     quantreg.predict(x)
     assert all(np.abs(quantreg.coefficients - [1.85617, 6.81286, 6.05586, 5.51965, 4.19864]) <= TOL)
 
@@ -112,7 +112,7 @@ def test_random_median_weights(random_data_weights):
     x = random_data_weights[["x0", "x1", "x2", "x3", "x4"]].values
     y = random_data_weights["y"].values
     weights = random_data_weights["weights"].values
-    quantreg.fit(x, y, tau, weights=weights)
+    quantreg.fit(x, y, tau, weights=weights, fit_intercept=False)
     quantreg.predict(x)
     assert all(np.abs(quantreg.coefficients - [1.59521, 2.17864, 4.68050, 3.10920, 9.63739]) <= TOL)
 
@@ -123,7 +123,7 @@ def test_random_lower_weights(random_data_weights):
     x = random_data_weights[["x0", "x1", "x2", "x3", "x4"]].values
     y = random_data_weights["y"].values
     weights = random_data_weights["weights"].values
-    quantreg.fit(x, y, tau, weights=weights)
+    quantreg.fit(x, y, tau, weights=weights, fit_intercept=False)
     quantreg.predict(x)
     assert all(np.abs(quantreg.coefficients - [0.63670, 1.27028, 4.81500, 3.08055, 8.69929]) <= TOL)
 
@@ -134,7 +134,7 @@ def test_random_upper_weights(random_data_weights):
     x = random_data_weights[["x0", "x1", "x2", "x3", "x4"]].values
     y = random_data_weights["y"].values
     weights = random_data_weights["weights"].values
-    quantreg.fit(x, y, tau, weights=weights)
+    quantreg.fit(x, y, tau, weights=weights, fit_intercept=False)
     quantreg.predict(x)
     assert all(np.abs(quantreg.coefficients - [3.47742, 2.07360, 4.51754, 4.15237, 9.58856]) <= TOL)
 
@@ -151,8 +151,8 @@ def test_changing_solver(random_data_no_weights):
 
     quantreg_scs = QuantileRegressionSolver(solver="SCS")
     quantreg_ecos = QuantileRegressionSolver(solver="ECOS")
-    quantreg_scs.fit(x, y, tau, save_problem=True)
-    quantreg_ecos.fit(x, y, tau, save_problem=True)
+    quantreg_scs.fit(x, y, tau, save_problem=True, fit_intercept=False)
+    quantreg_ecos.fit(x, y, tau, save_problem=True, fit_intercept=False)
 
     assert quantreg_scs.problem.value == pytest.approx(quantreg_ecos.problem.value, TOL)
 
@@ -165,8 +165,8 @@ def test_changing_solver_weights(random_data_weights):
 
     quantreg_scs = QuantileRegressionSolver(solver="SCS")
     quantreg_ecos = QuantileRegressionSolver(solver="ECOS")
-    quantreg_scs.fit(x, y, tau, weights=weights, save_problem=True)
-    quantreg_ecos.fit(x, y, tau, weights=weights, save_problem=True)
+    quantreg_scs.fit(x, y, tau, weights=weights, save_problem=True, fit_intercept=False)
+    quantreg_ecos.fit(x, y, tau, weights=weights, save_problem=True, fit_intercept=False)
 
     assert quantreg_scs.problem.value == pytest.approx(quantreg_ecos.problem.value, TOL)
 
@@ -183,14 +183,14 @@ def test_saving_problem(random_data_no_weights):
 
     quantreg = QuantileRegressionSolver(solver="ECOS")
 
-    quantreg.fit(x, y, tau, save_problem=False)
+    quantreg.fit(x, y, tau, save_problem=False, fit_intercept=False)
     assert quantreg.problem is None
 
-    quantreg.fit(x, y, tau, save_problem=True)
+    quantreg.fit(x, y, tau, save_problem=True, fit_intercept=False)
     assert quantreg.problem is not None
 
     # testing whether overwrite works
-    quantreg.fit(x, y, tau, save_problem=False)
+    quantreg.fit(x, y, tau, save_problem=False, fit_intercept=False)
     assert quantreg.problem is None
 
 
@@ -208,11 +208,11 @@ def test_weight_normalization_divide_by_zero(random_data_no_weights):
     quantreg = QuantileRegressionSolver(solver="ECOS")
 
     # Will succeed without weight normalization
-    quantreg.fit(x, y, tau, normalize_weights=False, weights=weights)
+    quantreg.fit(x, y, tau, normalize_weights=False, weights=weights, fit_intercept=False)
 
     # Will fail with weight normalization
     with pytest.raises(ZeroDivisionError):
-        quantreg.fit(x, y, tau, normalize_weights=True, weights=weights)
+        quantreg.fit(x, y, tau, normalize_weights=True, weights=weights, fit_intercept=False)
 
 
 def test_weight_normalization_same_fit(random_data_weights):
@@ -240,6 +240,7 @@ def test_weight_normalization_same_fit(random_data_weights):
 def test_regularization_with_intercept(random_data_no_weights):
     tau = 0.5
     x = random_data_no_weights[["x0", "x1", "x2", "x3", "x4"]].values
+    x[:,0] = 1
     y = random_data_no_weights["y"].values
 
     quantreg = QuantileRegressionSolver()
@@ -253,6 +254,16 @@ def test_regularization_with_intercept(random_data_no_weights):
     quantreg.fit(x, y, tau, save_problem=True)
     assert quantreg.problem.value < objective_w_reg
 
+def test_regularization_with_intercept_warning(random_data_no_weights, caplog):
+    caplog.clear()
+    tau = 0.5
+    x = random_data_no_weights[["x0", "x1", "x2", "x3", "x4"]].values
+    y = random_data_no_weights["y"].values
+
+    quantreg = QuantileRegressionSolver()
+    lambda_ = 1e6
+    with pytest.warns(UserWarning):    
+        quantreg.fit(x, y, tau, lambda_=lambda_, fit_intercept=True, save_problem=True)
 
 def test_regularization_without_intercept(random_data_no_weights):
     tau = 0.5
@@ -286,17 +297,8 @@ def test_ill_conditioned_warning():
     mu = np.asarray([1, 3, 5])
     sigma = np.asarray([[1, 0.9, 0], [0.9, 1, 0], [0, 0, 1]])
     x = random_number_generator.multivariate_normal(mu, sigma, size=3)
-    matrix_check = quantreg._check_matrix_condition(x)
-    assert not matrix_check
-
-    quantreg = QuantileRegressionSolver()
-
-    random_number_generator = np.random.RandomState(42)
-    mu = np.asarray([1, 3, 5])
-    sigma = np.asarray([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
-    x = random_number_generator.multivariate_normal(mu, sigma, size=3)
-    matrix_check = quantreg._check_matrix_condition(x)
-    assert matrix_check
+    with pytest.warns(UserWarning):
+        matrix_check = quantreg._check_matrix_condition(x)
 
 
 ########################
@@ -312,20 +314,20 @@ def test_no_nan_inf_error(random_data_weights):
 
     x[0, 0] = np.nan
     with pytest.raises(ValueError):
-        quantreg.fit(x, y, tau)
+        quantreg.fit(x, y, tau, fit_intercept=False)
 
     x[0, 0] = np.inf
     with pytest.raises(ValueError):
-        quantreg.fit(x, y, tau)
+        quantreg.fit(x, y, tau, fit_intercept=False)
 
     x = random_data_weights[["x0", "x1", "x2", "x3", "x4"]].values
     y[5] = np.nan
     with pytest.raises(ValueError):
-        quantreg.fit(x, y, tau)
+        quantreg.fit(x, y, tau, fit_intercept=False)
 
     y[5] = np.inf
     with pytest.raises(ValueError):
-        quantreg.fit(x, y, tau)
+        quantreg.fit(x, y, tau, fit_intercept=False)
 
     quantreg.coefficients = [4, 32, 4, 24, 7]
     x = np.vstack([x, [4, 2, 6, np.nan, 3]])

--- a/tests/test_quantile.py
+++ b/tests/test_quantile.py
@@ -240,7 +240,7 @@ def test_weight_normalization_same_fit(random_data_weights):
 def test_regularization_with_intercept(random_data_no_weights):
     tau = 0.5
     x = random_data_no_weights[["x0", "x1", "x2", "x3", "x4"]].values
-    x[:,0] = 1
+    x[:, 0] = 1
     y = random_data_no_weights["y"].values
 
     quantreg = QuantileRegressionSolver()
@@ -254,6 +254,7 @@ def test_regularization_with_intercept(random_data_no_weights):
     quantreg.fit(x, y, tau, save_problem=True)
     assert quantreg.problem.value < objective_w_reg
 
+
 def test_regularization_with_intercept_warning(random_data_no_weights, caplog):
     caplog.clear()
     tau = 0.5
@@ -262,8 +263,9 @@ def test_regularization_with_intercept_warning(random_data_no_weights, caplog):
 
     quantreg = QuantileRegressionSolver()
     lambda_ = 1e6
-    with pytest.warns(UserWarning):    
+    with pytest.warns(UserWarning):
         quantreg.fit(x, y, tau, lambda_=lambda_, fit_intercept=True, save_problem=True)
+
 
 def test_regularization_without_intercept(random_data_no_weights):
     tau = 0.5
@@ -298,7 +300,7 @@ def test_ill_conditioned_warning():
     sigma = np.asarray([[1, 0.9, 0], [0.9, 1, 0], [0, 0, 1]])
     x = random_number_generator.multivariate_normal(mu, sigma, size=3)
     with pytest.warns(UserWarning):
-        matrix_check = quantreg._check_matrix_condition(x)
+        quantreg._check_matrix_condition(x)
 
 
 ########################

--- a/tests/test_quantile.py
+++ b/tests/test_quantile.py
@@ -253,6 +253,7 @@ def test_regularization_with_intercept(random_data_no_weights):
     quantreg.fit(x, y, tau, save_problem=True)
     assert quantreg.problem.value < objective_w_reg
 
+
 def test_regularization_without_intercept(random_data_no_weights):
     tau = 0.5
     x = random_data_no_weights[["x0", "x1", "x2", "x3", "x4"]].values
@@ -263,8 +264,6 @@ def test_regularization_without_intercept(random_data_no_weights):
     quantreg.fit(x, y, tau, lambda_=lambda_, fit_intercept=False, save_problem=True)
     coefficients_w_reg = quantreg.coefficients
     assert all(np.abs(coefficients_w_reg - [0, 0, 0, 0, 0]) <= TOL)
-
-
 
 
 ########################

--- a/tests/test_quantile.py
+++ b/tests/test_quantile.py
@@ -237,20 +237,34 @@ def test_weight_normalization_same_fit(random_data_weights):
 ########################
 
 
-def test_regularization(random_data_no_weights):
+def test_regularization_with_intercept(random_data_no_weights):
     tau = 0.5
     x = random_data_no_weights[["x0", "x1", "x2", "x3", "x4"]].values
     y = random_data_no_weights["y"].values
 
     quantreg = QuantileRegressionSolver()
-    lambda_ = 1e8
-    quantreg.fit(x, y, tau, lambda_=lambda_, save_problem=True)
+    lambda_ = 1e6
+    quantreg.fit(x, y, tau, lambda_=lambda_, fit_intercept=True, save_problem=True)
     coefficients_w_reg = quantreg.coefficients
-    assert all(np.abs(coefficients_w_reg - [0, 0, 0, 0, 0]) <= TOL)
+    assert all(np.abs(coefficients_w_reg[1:] - [0, 0, 0, 0]) <= TOL)
+    assert np.abs(coefficients_w_reg[0]) > TOL
 
     objective_w_reg = quantreg.problem.value
     quantreg.fit(x, y, tau, save_problem=True)
     assert quantreg.problem.value < objective_w_reg
+
+def test_regularization_without_intercept(random_data_no_weights):
+    tau = 0.5
+    x = random_data_no_weights[["x0", "x1", "x2", "x3", "x4"]].values
+    y = random_data_no_weights["y"].values
+
+    quantreg = QuantileRegressionSolver()
+    lambda_ = 1e6
+    quantreg.fit(x, y, tau, lambda_=lambda_, fit_intercept=False, save_problem=True)
+    coefficients_w_reg = quantreg.coefficients
+    assert all(np.abs(coefficients_w_reg - [0, 0, 0, 0, 0]) <= TOL)
+
+
 
 
 ########################


### PR DESCRIPTION
## Description
We do not want to regularize the intercept column. Added a parameter to `solve` which specifies whether an intercept column is being included or not. If `fit_intercept = True` then we assume that the first coefficient is for the intercept and so is excluded from regularization. If `fit_intercept = False` then we assume that the first coefficient is **not** an intercept and is included in regularization.

## Jira Ticket

## Test Steps
Added a unit test to distinguish between the two cases:
```
tox
```