### PR TITLE
ELEX-3055: Update all `elex-solver` requirements in an attempt to silence numpy/pandas warnings in `elexmodel`

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 jupyter<=1.1.0
-numpy<=2.0
 matplotlib<=4.0.0
-pandas<1.4.0
+pandas>=2.1.1
 autopep8
 betamax
 betamax-serializers

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,3 @@
-jupyter<=1.1.0
-matplotlib<=4.0.0
 pandas>=2.1.1
 autopep8
 betamax

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from codecs import open
 
 from setuptools import find_packages, setup
 
-INSTALL_REQUIRES = ["cvxpy==1.4.1", "numpy==1.26.1", "scipy==1.11.3"]
+INSTALL_REQUIRES = ["cvxpy~=1.4", "numpy~=1.26", "scipy~=1.11"]
 
 THIS_FILE_DIR = os.path.dirname(__file__)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from codecs import open
 
 from setuptools import find_packages, setup
 
-INSTALL_REQUIRES = ["cvxpy<=1.2.0", "scipy<1.11.0"]
+INSTALL_REQUIRES = ["cvxpy==1.4.1", "numpy==1.26.1", "scipy==1.11.3"]
 
 THIS_FILE_DIR = os.path.dirname(__file__)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py3.10
+envlist=py3.10,py3.11
 skipdist=True
 
 [base]
@@ -17,7 +17,6 @@ commands=
 [testenv]
 deps=
   {[base]deps}
-basepython = python3.10
 commands=
   {[base]commands}
   pytest --cov-report term-missing --cov=elexsolver


### PR DESCRIPTION
## Description

Hello!  The changes in this PR help us progress towards the completion of [ELEX-3055](https://arcpublishing.atlassian.net/browse/ELEX-3055) in which we silence numpy/pandas/etc. warnings in `elexmodel` by upgrading its requirements to their latest versions.  `elex-solver` is one such requirement, hence this PR 😄 

## Jira Ticket

ELEX-3055

## Test Steps

`tox`, and/or running `elexmodel` commands along with [this PR](https://github.com/washingtonpost/elex-live-model/pull/81).

[ELEX-3055]: https://arcpublishing.atlassian.net/browse/ELEX-3055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ