### PR TITLE
ELEX-4413 update dependencies and switch to using the `Clarabel` solver

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from codecs import open
 
 from setuptools import find_packages, setup
 
-INSTALL_REQUIRES = ["cvxpy~=1.5", "numpy~=2.1", "scipy~=1.14"]
+INSTALL_REQUIRES = ["cvxpy~=1.5", "ecos~=2.0", "numpy~=2.1", "scipy~=1.14"]
 
 THIS_FILE_DIR = os.path.dirname(__file__)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from codecs import open
 
 from setuptools import find_packages, setup
 
-INSTALL_REQUIRES = ["cvxpy~=1.5", "ecos~=2.0", "numpy~=2.1", "scipy~=1.14"]
+INSTALL_REQUIRES = ["cvxpy~=1.5", "numpy~=2.1", "scipy~=1.14"]
 
 THIS_FILE_DIR = os.path.dirname(__file__)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from codecs import open
 
 from setuptools import find_packages, setup
 
-INSTALL_REQUIRES = ["cvxpy~=1.4", "numpy~=1.26", "scipy~=1.12"]
+INSTALL_REQUIRES = ["cvxpy~=1.5", "numpy~=2.1", "scipy~=1.14"]
 
 THIS_FILE_DIR = os.path.dirname(__file__)
 

--- a/src/elexsolver/QuantileRegressionSolver.py
+++ b/src/elexsolver/QuantileRegressionSolver.py
@@ -1,5 +1,4 @@
 import logging
-import warnings
 
 import cvxpy as cp
 import numpy as np
@@ -62,23 +61,17 @@ class QuantileRegressionSolver(LinearSolver):
         """
         Fits quantile regression with regularization
         TODO: convert this problem to use the dual like in the non regularization case
-        TODO: experiment with switching to CLARABEL instead of ECOS
         """
-
-        with warnings.catch_warnings():
-            # silence the warning we receive from cvxpy about having not yet switched away from ECOS
-            warnings.simplefilter("ignore", FutureWarning)
-
-            arguments = {cp.ECOS: {"max_iters": 10000}}
-            coefficients = cp.Variable((x.shape[1],))
-            y_hat = x @ coefficients
-            residual = y - y_hat
-            loss_function = cp.sum(cp.multiply(weights, 0.5 * cp.abs(residual) + (tau - 0.5) * residual))
-            loss_function += lambda_ * self._get_regularizer(coefficients, regularize_intercept, n_feat_ignore_reg)
-            objective = cp.Minimize(loss_function)
-            problem = cp.Problem(objective)
-            problem.solve(solver=cp.ECOS, **arguments.get(cp.ECOS, {}))
-            return coefficients.value
+        arguments = {cp.CLARABEL: {"max_iter": 10000}}
+        coefficients = cp.Variable((x.shape[1],))
+        y_hat = x @ coefficients
+        residual = y - y_hat
+        loss_function = cp.sum(cp.multiply(weights, 0.5 * cp.abs(residual) + (tau - 0.5) * residual))
+        loss_function += lambda_ * self._get_regularizer(coefficients, regularize_intercept, n_feat_ignore_reg)
+        objective = cp.Minimize(loss_function)
+        problem = cp.Problem(objective)
+        problem.solve(solver=cp.CLARABEL, **arguments.get(cp.CLARABEL, {}))
+        return coefficients.value
 
     def fit(
         self,


### PR DESCRIPTION
## Description

Hi! The changes in this PR update `elex-solver`'s dependencies to their latest versions and ~~silences a warning produced by `cvxpy` about the fact that we're still using the `ECOS` solver~~ switches `QuantileRegressionSolver`'s `cvxpy` solver from `ECOS` to `Clarabel` 🎉 

~~Switching from `ECOS` to `cvxpy`'s recommendation of `CLARABEL` is pretty easy and will probably result in absolutely no changes in terms of the predictions produced by our model, but IMO that's something we'd want to test pretty extensively before making the switch 😬  So I'm silencing the `warning` here per `cvxpy`'s recommendation.~~

## Jira Ticket

[ELEX-4413]

## Test Steps

`tox` and/or `pip install -e .` and run the `elexmodel` and/or test bed commands of your choice 🎉 

[ELEX-4413]: https://arcpublishing.atlassian.net/browse/ELEX-4413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ