### PR TITLE
Release/2.1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(os.path.join(THIS_FILE_DIR, "README.md"), encoding="utf-8") as f:
     LONG_DESCRIPTION = f.read()
 
 # The full version, including alpha/beta/rc tags
-RELEASE = "2.1.0"
+RELEASE = "2.1.1"
 # The short X.Y version
 VERSION = ".".join(RELEASE.split(".")[:2])
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from codecs import open
 
 from setuptools import find_packages, setup
 
-INSTALL_REQUIRES = ["cvxpy~=1.5", "numpy~=2.1", "scipy~=1.14"]
+INSTALL_REQUIRES = ["cvxpy~=1.5", "ecos~=2.0", "numpy~=2.1", "scipy~=1.14"]
 
 THIS_FILE_DIR = os.path.dirname(__file__)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from codecs import open
 
 from setuptools import find_packages, setup
 
-INSTALL_REQUIRES = ["cvxpy~=1.5", "ecos~=2.0", "numpy~=2.1", "scipy~=1.14"]
+INSTALL_REQUIRES = ["cvxpy~=1.5", "numpy~=2.1", "scipy~=1.14"]
 
 THIS_FILE_DIR = os.path.dirname(__file__)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from codecs import open
 
 from setuptools import find_packages, setup
 
-INSTALL_REQUIRES = ["cvxpy~=1.4", "numpy~=1.26", "scipy~=1.12"]
+INSTALL_REQUIRES = ["cvxpy~=1.5", "numpy~=2.1", "scipy~=1.14"]
 
 THIS_FILE_DIR = os.path.dirname(__file__)
 

--- a/src/elexsolver/QuantileRegressionSolver.py
+++ b/src/elexsolver/QuantileRegressionSolver.py
@@ -1,5 +1,4 @@
 import logging
-import warnings
 
 import cvxpy as cp
 import numpy as np
@@ -62,23 +61,17 @@ class QuantileRegressionSolver(LinearSolver):
         """
         Fits quantile regression with regularization
         TODO: convert this problem to use the dual like in the non regularization case
-        TODO: experiment with switching to CLARABEL instead of ECOS
         """
-
-        with warnings.catch_warnings():
-            # silence the warning we receive from cvxpy about having not yet switched away from ECOS
-            warnings.simplefilter("ignore", FutureWarning)
-
-            arguments = {cp.ECOS: {"max_iters": 10000}}
-            coefficients = cp.Variable((x.shape[1],))
-            y_hat = x @ coefficients
-            residual = y - y_hat
-            loss_function = cp.sum(cp.multiply(weights, 0.5 * cp.abs(residual) + (tau - 0.5) * residual))
-            loss_function += lambda_ * self._get_regularizer(coefficients, regularize_intercept, n_feat_ignore_reg)
-            objective = cp.Minimize(loss_function)
-            problem = cp.Problem(objective)
-            problem.solve(solver=cp.ECOS, **arguments.get(cp.ECOS, {}))
-            return coefficients.value
+        arguments = {cp.CLARABEL: {"max_iter": 10000}}
+        coefficients = cp.Variable((x.shape[1],))
+        y_hat = x @ coefficients
+        residual = y - y_hat
+        loss_function = cp.sum(cp.multiply(weights, 0.5 * cp.abs(residual) + (tau - 0.5) * residual))
+        loss_function += lambda_ * self._get_regularizer(coefficients, regularize_intercept, n_feat_ignore_reg)
+        objective = cp.Minimize(loss_function)
+        problem = cp.Problem(objective)
+        problem.solve(solver=cp.CLARABEL, **arguments.get(cp.CLARABEL, {}))
+        return coefficients.value
 
     def fit(
         self,


### PR DESCRIPTION
## Description

Hi!  The changes in this PR will create `elex-solver` version 2.1.1 🎉 

## Jira Tickets and PRs

* PR #22 which resolves [ELEX-4413] by updating `elex-solver`'s dependencies to their latest versions and switching `QuantileRegressionSolver`'s solver from `ECOS` to `Clarabel`

## Test Steps

`tox` etc.

[ELEX-4413]: https://arcpublishing.atlassian.net/browse/ELEX-4413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ